### PR TITLE
Add initial React frontend skeleton

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "gymbrorecipes",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "idb-keyval": "^6.2.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.3.0"
+  },
+  "devDependencies": {
+    "vite": "^4.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "tailwindcss": "^3.0.0",
+    "autoprefixer": "^10.0.0",
+    "postcss": "^8.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>GymBroRecipes</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/index.jsx"></script>
+</body>
+</html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react';
+import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+import { get } from 'idb-keyval';
+import Home from './components/Home';
+import WorkoutPlanner from './components/WorkoutPlanner';
+import NutritionTracker from './components/NutritionTracker';
+import BodyMetrics from './components/BodyMetrics';
+import UpgradeBanner from './components/UpgradeBanner';
+
+function App() {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchUser() {
+      const stored = await get('user');
+      setUser(stored || { is_paid: false });
+      setLoading(false);
+    }
+    fetchUser();
+  }, []);
+
+  if (loading) {
+    return <div className="text-center p-4">Loading...</div>;
+  }
+
+  return (
+    <Router>
+      <div className="min-h-screen flex flex-col">
+        <header className="bg-blue-600 text-white p-4 flex justify-between items-center">
+          <h1 className="text-lg font-bold">GymBroRecipes</h1>
+          <nav className="space-x-4">
+            <Link className="hover:underline" to="/">Home</Link>
+            <Link className="hover:underline" to="/workout">Workouts</Link>
+            <Link className="hover:underline" to="/nutrition">Nutrition</Link>
+            <Link className="hover:underline" to="/metrics">Metrics</Link>
+          </nav>
+        </header>
+
+        {!user.is_paid && <UpgradeBanner />}
+
+        <main className="flex-1 p-4">
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/workout" element={<WorkoutPlanner />} />
+            <Route path="/nutrition" element={<NutritionTracker />} />
+            <Route path="/metrics" element={<BodyMetrics />} />
+          </Routes>
+        </main>
+
+        <footer className="bg-gray-100 text-center p-4 text-sm">
+          &copy; {new Date().getFullYear()} GymBroRecipes
+        </footer>
+      </div>
+    </Router>
+  );
+}
+
+export default App;

--- a/src/components/BodyMetrics.jsx
+++ b/src/components/BodyMetrics.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const BodyMetrics = () => (
+  <div>
+    <h2 className="text-xl font-semibold mb-2">Body Metrics</h2>
+    <p className="text-gray-700">Record weight and body measurements.</p>
+  </div>
+);
+
+export default BodyMetrics;

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const Home = () => (
+  <div>
+    <h2 className="text-xl font-semibold mb-2">Welcome to GymBroRecipes</h2>
+    <p className="text-gray-700">Your personal fitness companion.</p>
+  </div>
+);
+
+export default Home;

--- a/src/components/NutritionTracker.jsx
+++ b/src/components/NutritionTracker.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const NutritionTracker = () => (
+  <div>
+    <h2 className="text-xl font-semibold mb-2">Nutrition Tracker</h2>
+    <p className="text-gray-700">Track your meals and macros.</p>
+  </div>
+);
+
+export default NutritionTracker;

--- a/src/components/UpgradeBanner.jsx
+++ b/src/components/UpgradeBanner.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const UpgradeBanner = () => (
+  <div className="bg-yellow-200 text-yellow-800 p-4 text-center">
+    <p className="mb-2">Unlock cloud sync and more features!</p>
+    <Link to="/upgrade" className="underline font-medium">Upgrade Now</Link>
+  </div>
+);
+
+export default UpgradeBanner;

--- a/src/components/WorkoutPlanner.jsx
+++ b/src/components/WorkoutPlanner.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const WorkoutPlanner = () => (
+  <div>
+    <h2 className="text-xl font-semibold mb-2">Workout Planner</h2>
+    <p className="text-gray-700">Plan and log your workouts here.</p>
+  </div>
+);
+
+export default WorkoutPlanner;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./public/**/*.html', './src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    open: true,
+  },
+});


### PR DESCRIPTION
## Summary
- scaffold Vite + Tailwind setup
- add base React layout with routing and upgrade banner
- stub pages (Home, WorkoutPlanner, NutritionTracker, BodyMetrics)
- provide minimal HTML entry point

## Testing
- `npm install` *(fails: 403 Forbidden due to lack of internet)*

------
https://chatgpt.com/codex/tasks/task_e_687cd2db8e98832c9a459ef3121d5eb9