### PR TITLE
Add IndexedDB helper

### DIFF
--- a/utils/indexedDB.js
+++ b/utils/indexedDB.js
@@ -1,0 +1,34 @@
+import { get, set, del, clear } from 'idb-keyval';
+
+export async function saveData(key, value) {
+  try {
+    await set(key, value);
+  } catch (err) {
+    console.warn('Error saving data', err);
+  }
+}
+
+export async function getData(key) {
+  try {
+    return await get(key);
+  } catch (err) {
+    console.warn('Error getting data', err);
+    return undefined;
+  }
+}
+
+export async function deleteData(key) {
+  try {
+    await del(key);
+  } catch (err) {
+    console.warn('Error deleting data', err);
+  }
+}
+
+export async function clearAllData() {
+  try {
+    await clear();
+  } catch (err) {
+    console.warn('Error clearing data', err);
+  }
+}


### PR DESCRIPTION
## Summary
- add `utils/indexedDB.js` with helper methods for common IndexedDB actions

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d2292a048832ca144b4f4fcdce967