### PR TITLE
Add supabase sync utility

### DIFF
--- a/utils/supabaseClient.js
+++ b/utils/supabaseClient.js
@@ -1,0 +1,48 @@
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = import.meta.env.SUPABASE_URL;
+const SUPABASE_ANON_KEY = import.meta.env.SUPABASE_ANON_KEY;
+
+export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+async function isAuthenticated() {
+  const { data, error } = await supabase.auth.getUser();
+  if (error || !data?.user) {
+    console.log('User not authenticated');
+    return null;
+  }
+  return data.user;
+}
+
+export async function syncWorkoutToCloud(data) {
+  const user = await isAuthenticated();
+  if (!user) return;
+  const { error } = await supabase.from('workouts').insert([data]);
+  if (error) {
+    console.error('Failed to sync workout', error);
+  } else {
+    console.log('Workout synced successfully');
+  }
+}
+
+export async function syncNutritionToCloud(data) {
+  const user = await isAuthenticated();
+  if (!user) return;
+  const { error } = await supabase.from('nutrition_logs').insert([data]);
+  if (error) {
+    console.error('Failed to sync nutrition log', error);
+  } else {
+    console.log('Nutrition log synced successfully');
+  }
+}
+
+export async function syncMetricsToCloud(data) {
+  const user = await isAuthenticated();
+  if (!user) return;
+  const { error } = await supabase.from('body_metrics').insert([data]);
+  if (error) {
+    console.error('Failed to sync metrics', error);
+  } else {
+    console.log('Metrics synced successfully');
+  }
+}


### PR DESCRIPTION
## Summary
- create `utils/supabaseClient.js` to centralize Supabase logic
- expose helper functions to sync workouts, nutrition logs and metrics

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d24c13f40832c8396828b9f31c92e