### PR TITLE
Add GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,43 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20.x
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          publish_branch: gh-pages
+
+      # Optional: Deploy to Netlify using Netlify CLI
+      # - name: Netlify Deploy
+      #   if: ${{ false }} # Remove this line when enabling Netlify deploy
+      #   uses: actions/setup-node@v3
+      #   with:
+      #     node-version: 20.x
+      #   run: |
+      #     npm install -g netlify-cli
+      #     netlify deploy --dir=dist --prod --site=$NETLIFY_SITE_ID --auth=$NETLIFY_AUTH_TOKEN
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for deploying the Vite build to GitHub Pages
- include commented Netlify deploy section for optional usage

## Testing
- `npm run build` *(fails: vite not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687d27892ac4832cb3e22e2a2a9f95ab