### PR TITLE
Add privacy policy, license and new features

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 GymBroRecipes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/backend/functions/calculatePRs.js
+++ b/backend/functions/calculatePRs.js
@@ -1,0 +1,19 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const serviceKey = process.env.SUPABASE_SERVICE_KEY;
+const supabase = createClient(supabaseUrl, serviceKey);
+
+export async function calculatePRs(userId) {
+  const { data, error } = await supabase
+    .from('workout_exercises')
+    .select('exercise_id, weight')
+    .eq('user_id', userId);
+  if (error) throw error;
+
+  return data.reduce((acc, row) => {
+    const current = acc[row.exercise_id] || 0;
+    acc[row.exercise_id] = row.weight > current ? row.weight : current;
+    return acc;
+  }, {});
+}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,54 @@
+openapi: 3.0.0
+info:
+  title: GymBroRecipes API
+  version: '1.0'
+paths:
+  /auth/signup:
+    post:
+      summary: Create a new user account
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                password:
+                  type: string
+      responses:
+        '200':
+          description: Signed up
+  /auth/login:
+    post:
+      summary: Sign in a user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                password:
+                  type: string
+      responses:
+        '200':
+          description: Login successful
+  /rpc/startCheckout:
+    post:
+      summary: Start paid upgrade checkout
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                userId:
+                  type: string
+      responses:
+        '200':
+          description: Checkout session created

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,0 +1,5 @@
+# Privacy Policy
+
+GymBroRecipes is built with your privacy in mind. Your workout logs, nutrition data and body metrics are stored locally in your browser by default. We do **not** collect or transmit your personal data unless you choose to upgrade and enable cloud sync.
+
+Upgrading enables secure synchronization via Supabase so you can access your data across devices. This sync is optional, encrypted in transit, and only occurs after you give permission. We don't run ads or third‑party trackers and we never sell your information. You remain in full control and can export or delete your data at any time.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+export default {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
+  transform: {},
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "idb-keyval": "^6.2.0",
@@ -21,6 +22,9 @@
     "@vitejs/plugin-react": "^4.0.0",
     "tailwindcss": "^3.0.0",
     "autoprefixer": "^10.0.0",
-    "postcss": "^8.0.0"
+    "postcss": "^8.0.0",
+    "jest": "^29.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import Home from './components/Home';
 import WorkoutPlanner from './components/WorkoutPlanner';
 import NutritionTracker from './components/NutritionTracker';
 import BodyMetrics from './components/BodyMetrics';
+import ProgressPhotos from './components/ProgressPhotos';
 import UpgradeBanner from './components/UpgradeBanner';
 
 function App() {
@@ -34,6 +35,7 @@ function App() {
             <Link className="hover:underline" to="/workout">Workouts</Link>
             <Link className="hover:underline" to="/nutrition">Nutrition</Link>
             <Link className="hover:underline" to="/metrics">Metrics</Link>
+            <Link className="hover:underline" to="/photos">Photos</Link>
           </nav>
         </header>
 
@@ -45,6 +47,7 @@ function App() {
             <Route path="/workout" element={<WorkoutPlanner />} />
             <Route path="/nutrition" element={<NutritionTracker />} />
             <Route path="/metrics" element={<BodyMetrics />} />
+            <Route path="/photos" element={<ProgressPhotos />} />
           </Routes>
         </main>
 

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -1,10 +1,77 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { get } from 'idb-keyval';
+import { createClient } from '@supabase/supabase-js';
 
-const Home = () => (
-  <div>
-    <h2 className="text-xl font-semibold mb-2">Welcome to GymBroRecipes</h2>
-    <p className="text-gray-700">Your personal fitness companion.</p>
-  </div>
-);
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+const Home = () => {
+  const [user, setUser] = useState(null);
+  const [stats, setStats] = useState({ workouts: 0, meals: 0, metrics: 0 });
+
+  useEffect(() => {
+    async function load() {
+      const stored = await get('user');
+      const u = stored || { is_paid: false };
+      setUser(u);
+
+      if (!u.is_paid) {
+        const workouts = (await get('workouts')) || [];
+        const meals = (await get('nutrition_logs')) || [];
+        const metrics = (await get('body_metrics')) || [];
+        setStats({
+          workouts: workouts.length,
+          meals: meals.length,
+          metrics: metrics.length,
+        });
+      } else {
+        try {
+          const [{ count: w }, { count: n }, { count: m }] = await Promise.all([
+            supabase.from('workouts').select('*', { count: 'exact', head: true }),
+            supabase
+              .from('nutrition_logs')
+              .select('*', { count: 'exact', head: true }),
+            supabase
+              .from('body_metrics')
+              .select('*', { count: 'exact', head: true }),
+          ]);
+          setStats({ workouts: w || 0, meals: n || 0, metrics: m || 0 });
+        } catch (err) {
+          console.error('Failed to fetch stats', err);
+        }
+      }
+    }
+    load();
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold">Welcome to GymBroRecipes</h2>
+      <p className="text-gray-700 dark:text-gray-300">
+        Track workouts, meals and body metrics offline. Upgrade any time to sync
+        your data securely across devices.
+      </p>
+
+      <div className="bg-gray-100 dark:bg-gray-800 p-4 rounded">
+        <h3 className="font-medium mb-1">Your Stats</h3>
+        <p>Workouts logged: {stats.workouts}</p>
+        <p>Nutrition logs: {stats.meals}</p>
+        <p>Body metric entries: {stats.metrics}</p>
+      </div>
+
+      {user && !user.is_paid && (
+        <div className="text-center">
+          <button
+            onClick={() => alert('Redirecting to upgrade...')}
+            className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+          >
+            Upgrade for Cloud Sync
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
 
 export default Home;

--- a/src/components/ProgressPhotos.jsx
+++ b/src/components/ProgressPhotos.jsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from 'react';
+import { get } from 'idb-keyval';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+const ProgressPhotos = () => {
+  const [user, setUser] = useState(null);
+  const [photos, setPhotos] = useState([]);
+  const [uploading, setUploading] = useState(false);
+
+  useEffect(() => {
+    async function loadUser() {
+      const stored = await get('user');
+      setUser(stored || { is_paid: false });
+    }
+    loadUser();
+  }, []);
+
+  useEffect(() => {
+    if (user?.is_paid) {
+      loadPhotos();
+    }
+  }, [user]);
+
+  async function loadPhotos() {
+    try {
+      const { data, error } = await supabase.storage
+        .from('progress_photos')
+        .list(user.id);
+      if (error) throw error;
+      setPhotos(data || []);
+    } catch (err) {
+      console.error('Error loading photos', err);
+    }
+  }
+
+  async function handleUpload(e) {
+    const file = e.target.files?.[0];
+    if (!file || !user) return;
+    setUploading(true);
+    const filePath = `${user.id}/${Date.now()}-${file.name}`;
+    try {
+      const { error } = await supabase.storage
+        .from('progress_photos')
+        .upload(filePath, file);
+      if (error) throw error;
+      await loadPhotos();
+    } catch (err) {
+      console.error('Upload failed', err);
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  if (!user) return null;
+
+  if (!user.is_paid) {
+    return <p className="text-center">Upgrade to upload progress photos.</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold">Progress Photos</h2>
+      <input type="file" accept="image/*" onChange={handleUpload} disabled={uploading} />
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
+        {photos.map((p) => {
+          const url = supabase.storage
+            .from('progress_photos')
+            .getPublicUrl(`${user.id}/${p.name}`).data.publicUrl;
+          return <img key={p.name} src={url} alt="Progress" className="rounded" />;
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default ProgressPhotos;

--- a/src/components/__tests__/WorkoutPlanner.test.jsx
+++ b/src/components/__tests__/WorkoutPlanner.test.jsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import WorkoutPlanner from '../WorkoutPlanner';
+import React from 'react';
+
+test('renders Workout Planner heading', () => {
+  render(<WorkoutPlanner />);
+  const heading = screen.getByText(/Workout Planner/i);
+  expect(heading).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add plain-language privacy policy
- license project under MIT
- expand Home page with stats and upgrade callout
- add progress photos component with Supabase storage
- document API via OpenAPI spec
- provide backend function to calculate PRs
- add minimal unit test scaffolding
- update navigation and route for photos

## Testing
- `npm test --silent` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687d29cce424832cb04c143841e7e1c3