### PR TITLE
Fix path for GitHub Pages assets

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,12 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  // When deploying to GitHub Pages the site will be served from
+  // https://<user>.github.io/<repo>/, so we need to prefix asset URLs
+  // with the repository name. This prevents requests for assets like
+  // /assets/index.js from returning the 404 page (served as text/html)
+  // which caused the "disallowed MIME type" error.
+  base: '/GymBroRecipes/',
   plugins: [react()],
   server: {
     open: true,


### PR DESCRIPTION
## Summary
- update Vite config with base URL for GitHub Pages

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d2e0118c0832cade1210f95192090