### PR TITLE
Fix Supabase env vars for Netlify

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ If you prefer Netlify, connect the repo in your Netlify dashboard or deploy manu
 ```bash
 netlify deploy --dir=dist --prod
 ```
+Make sure to configure the `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` variables
+in your Netlify environment settings so the frontend can connect to your Supabase
+project after deployment.
 
 ## Privacy & Data Ownership
 All data stays on your device unless you enable cloud sync. There are no analytics or third‑party trackers. You can export or delete your information at any time and you remain the sole owner of your data.

--- a/utils/supabaseClient.js
+++ b/utils/supabaseClient.js
@@ -1,7 +1,9 @@
 import { createClient } from '@supabase/supabase-js';
 
-const SUPABASE_URL = import.meta.env.SUPABASE_URL;
-const SUPABASE_ANON_KEY = import.meta.env.SUPABASE_ANON_KEY;
+// Vite exposes env variables prefixed with VITE_ to the browser at build time.
+// Without the prefix these will be undefined in production (e.g. Netlify).
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 


### PR DESCRIPTION
## Summary
- fix Supabase client env vars so Vite exposes them in Netlify
- document Netlify env vars in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d381fd034832ca6ef28fb58d5b927