### PR TITLE
Update styling across app

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { get } from 'idb-keyval';
 import Home from './components/Home';
 import WorkoutPlanner from './components/WorkoutPlanner';
@@ -7,6 +7,7 @@ import NutritionTracker from './components/NutritionTracker';
 import BodyMetrics from './components/BodyMetrics';
 import ProgressPhotos from './components/ProgressPhotos';
 import UpgradeBanner from './components/UpgradeBanner';
+import Link from './components/ui/Link';
 
 function App() {
   const [user, setUser] = useState(null);
@@ -22,7 +23,11 @@ function App() {
   }, []);
 
   if (loading) {
-    return <div className="text-center p-4">Loading...</div>;
+    return (
+      <div className="text-center p-4 text-base md:text-lg leading-relaxed text-gray-700 dark:text-gray-100">
+        Loading...
+      </div>
+    );
   }
 
   return (
@@ -30,13 +35,13 @@ function App() {
       <div className="min-h-screen flex flex-col">
         <header className="sticky top-0 z-10 bg-slate-900/50 backdrop-blur">
           <div className="container mx-auto px-6 py-4 flex justify-between items-center">
-            <h1 className="text-2xl font-bold text-white">GymBroRecipes</h1>
+            <h1 className="text-3xl font-bold md:text-4xl text-white">GymBroRecipes</h1>
             <nav className="space-x-4">
-              <Link className="text-gray-300 hover:text-blue-400 transition-colors duration-300" to="/">Home</Link>
-              <Link className="text-gray-300 hover:text-blue-400 transition-colors duration-300" to="/workout">Workouts</Link>
-              <Link className="text-gray-300 hover:text-blue-400 transition-colors duration-300" to="/nutrition">Nutrition</Link>
-              <Link className="text-gray-300 hover:text-blue-400 transition-colors duration-300" to="/metrics">Metrics</Link>
-              <Link className="text-gray-300 hover:text-blue-400 transition-colors duration-300" to="/photos">Photos</Link>
+              <Link className="text-base font-medium text-gray-300 hover:text-blue-400 transition-colors" to="/">Home</Link>
+              <Link className="text-base font-medium text-gray-300 hover:text-blue-400 transition-colors" to="/workout">Workouts</Link>
+              <Link className="text-base font-medium text-gray-300 hover:text-blue-400 transition-colors" to="/nutrition">Nutrition</Link>
+              <Link className="text-base font-medium text-gray-300 hover:text-blue-400 transition-colors" to="/metrics">Metrics</Link>
+              <Link className="text-base font-medium text-gray-300 hover:text-blue-400 transition-colors" to="/photos">Photos</Link>
             </nav>
           </div>
         </header>
@@ -53,7 +58,7 @@ function App() {
           </Routes>
         </main>
 
-        <footer className="bg-slate-900/50 text-gray-400 text-center py-4">
+        <footer className="bg-slate-900/50 dark:bg-gray-900/50 text-gray-400 dark:text-gray-400 text-center py-4">
           &copy; {new Date().getFullYear()} GymBroRecipes
         </footer>
       </div>

--- a/src/components/BodyMetrics.jsx
+++ b/src/components/BodyMetrics.jsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { get, set } from 'idb-keyval';
 import { createClient } from '@supabase/supabase-js';
+import Button from './ui/Button';
+import Input from './ui/Input';
+import Label from './ui/Label';
+import { Card, CardHeader, CardContent } from './ui/Card';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
@@ -94,90 +98,93 @@ const BodyMetrics = () => {
     .sort((a, b) => new Date(b.date) - new Date(a.date));
 
   return (
-    <div className="max-w-xl mx-auto space-y-4 text-gray-300">
-      <h2 className="text-4xl md:text-5xl font-bold text-white mb-4 text-center">
-        Body Metrics
-      </h2>
+    <div className="max-w-xl mx-auto space-y-4">
+      <h1 className="text-3xl font-bold md:text-4xl text-center">Body Metrics</h1>
 
-      <div className="grid grid-cols-2 gap-2">
-        <input
-          type="number"
-          placeholder="Weight (kg)"
-          value={weight}
-          onChange={(e) => setWeight(e.target.value)}
-          className="border border-slate-600/50 rounded p-2 bg-slate-800/50"
-        />
-        <input
-          type="number"
-          placeholder="Body Fat %"
-          value={bodyFat}
-          onChange={(e) => setBodyFat(e.target.value)}
-          className="border border-slate-600/50 rounded p-2 bg-slate-800/50"
-        />
-        <input
-          type="number"
-          placeholder="Chest"
-          value={chest}
-          onChange={(e) => setChest(e.target.value)}
-          className="border border-slate-600/50 rounded p-2 bg-slate-800/50"
-        />
-        <input
-          type="number"
-          placeholder="Waist"
-          value={waist}
-          onChange={(e) => setWaist(e.target.value)}
-          className="border border-slate-600/50 rounded p-2 bg-slate-800/50"
-        />
-        <input
-          type="number"
-          placeholder="Arms"
-          value={arms}
-          onChange={(e) => setArms(e.target.value)}
-          className="border border-slate-600/50 rounded p-2 bg-slate-800/50"
-        />
-        <input
-          type="number"
-          placeholder="Thighs"
-          value={thighs}
-          onChange={(e) => setThighs(e.target.value)}
-          className="border border-slate-600/50 rounded p-2 bg-slate-800/50"
-        />
-      </div>
+      <Card className="mt-4">
+        <CardContent className="grid grid-cols-2 gap-2">
+          <Input
+            type="number"
+            aria-label="Weight"
+            placeholder="Weight (kg)"
+            value={weight}
+            onChange={(e) => setWeight(e.target.value)}
+          />
+          <Input
+            type="number"
+            aria-label="Body Fat %"
+            placeholder="Body Fat %"
+            value={bodyFat}
+            onChange={(e) => setBodyFat(e.target.value)}
+          />
+          <Input
+            type="number"
+            aria-label="Chest"
+            placeholder="Chest"
+            value={chest}
+            onChange={(e) => setChest(e.target.value)}
+          />
+          <Input
+            type="number"
+            aria-label="Waist"
+            placeholder="Waist"
+            value={waist}
+            onChange={(e) => setWaist(e.target.value)}
+          />
+          <Input
+            type="number"
+            aria-label="Arms"
+            placeholder="Arms"
+            value={arms}
+            onChange={(e) => setArms(e.target.value)}
+          />
+          <Input
+            type="number"
+            aria-label="Thighs"
+            placeholder="Thighs"
+            value={thighs}
+            onChange={(e) => setThighs(e.target.value)}
+          />
+        </CardContent>
+      </Card>
 
-      <button
-        className="px-8 py-4 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-lg transition-colors duration-300 shadow-lg hover:shadow-xl w-full"
+      <Button
+        className="mt-4 w-full"
         onClick={saveEntry}
         disabled={!weight}
+        aria-label="Save Metrics"
       >
         Save Metrics
-      </button>
+      </Button>
 
       {entries.length > 0 && (
-        <div className="space-y-2">
-          <div className="flex justify-between items-center">
-            <h3 className="font-medium">Past Entries</h3>
+        <Card className="mt-4">
+          <CardHeader className="flex justify-between items-center">
+            <h2 className="text-xl font-semibold md:text-2xl">Past Entries</h2>
             <select
               value={filter}
               onChange={(e) => setFilter(e.target.value)}
-              className="border border-slate-600/50 rounded p-1 bg-slate-800/50"
+              className="border rounded p-1 dark:bg-gray-800"
             >
               <option value="all">All</option>
               <option value="7">Last 7 days</option>
               <option value="30">Last 30 days</option>
             </select>
-          </div>
-          <ul className="space-y-1">
-            {filteredEntries.map((e, idx) => (
-              <li
-                key={idx}
-                className="flex justify-between bg-slate-900/50 p-2 rounded border border-slate-700/50"
-              >
-                <span>{new Date(e.date).toLocaleDateString()}</span>
-                <span>{e.weight}kg / {e.body_fat_pct}% BF</span>
-              </li>
-            ))}
-          </ul>
-        </div>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-1">
+              {filteredEntries.map((e, idx) => (
+                <li
+                  key={idx}
+                  className="flex justify-between bg-slate-900/50 p-2 rounded border border-slate-700/50"
+                >
+                  <span>{new Date(e.date).toLocaleDateString()}</span>
+                  <span>{e.weight}kg / {e.body_fat_pct}% BF</span>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
       )}
     </div>
   );

--- a/src/components/Charts.jsx
+++ b/src/components/Charts.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Card, CardHeader, CardContent } from './ui/Card';
 import {
   LineChart,
   Line,
@@ -45,45 +46,57 @@ const Charts = ({ bodyMetricsData = [], nutritionData = [], workoutData = [] }) 
     .sort((a, b) => new Date(a.date) - new Date(b.date));
 
   return (
-    <div className="grid gap-4 md:grid-cols-2 dark:text-white">
-      <div className="bg-white dark:bg-gray-800 p-4 rounded shadow">
-        <h3 className="font-semibold mb-2">Weight Over Time</h3>
-        <ResponsiveContainer width="100%" height={200}>
-          <LineChart data={weightData} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
-            <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.2} />
-            <XAxis dataKey="date" />
-            <YAxis />
-            <Tooltip />
-            <Line type="monotone" dataKey="weight" stroke="#3b82f6" strokeWidth={2} />
-          </LineChart>
-        </ResponsiveContainer>
-      </div>
+    <div className="grid gap-4 md:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <h3 className="text-lg font-semibold">Weight Over Time</h3>
+        </CardHeader>
+        <CardContent>
+          <ResponsiveContainer width="100%" height={200}>
+            <LineChart data={weightData} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.2} />
+              <XAxis dataKey="date" />
+              <YAxis />
+              <Tooltip />
+              <Line type="monotone" dataKey="weight" stroke="#3b82f6" strokeWidth={2} />
+            </LineChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
 
-      <div className="bg-white dark:bg-gray-800 p-4 rounded shadow">
-        <h3 className="font-semibold mb-2">Calories Over Time</h3>
-        <ResponsiveContainer width="100%" height={200}>
-          <LineChart data={caloriesData} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
-            <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.2} />
-            <XAxis dataKey="date" />
-            <YAxis />
-            <Tooltip />
-            <Line type="monotone" dataKey="calories" stroke="#10b981" strokeWidth={2} />
-          </LineChart>
-        </ResponsiveContainer>
-      </div>
+      <Card>
+        <CardHeader>
+          <h3 className="text-lg font-semibold">Calories Over Time</h3>
+        </CardHeader>
+        <CardContent>
+          <ResponsiveContainer width="100%" height={200}>
+            <LineChart data={caloriesData} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.2} />
+              <XAxis dataKey="date" />
+              <YAxis />
+              <Tooltip />
+              <Line type="monotone" dataKey="calories" stroke="#10b981" strokeWidth={2} />
+            </LineChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
 
-      <div className="bg-white dark:bg-gray-800 p-4 rounded shadow md:col-span-2">
-        <h3 className="font-semibold mb-2">Best Squat Weight Over Time</h3>
-        <ResponsiveContainer width="100%" height={200}>
-          <LineChart data={strengthData} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
-            <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.2} />
-            <XAxis dataKey="date" />
-            <YAxis />
-            <Tooltip />
-            <Line type="monotone" dataKey="squat" stroke="#ef4444" strokeWidth={2} />
-          </LineChart>
-        </ResponsiveContainer>
-      </div>
+      <Card className="md:col-span-2">
+        <CardHeader>
+          <h3 className="text-lg font-semibold">Best Squat Weight Over Time</h3>
+        </CardHeader>
+        <CardContent>
+          <ResponsiveContainer width="100%" height={200}>
+            <LineChart data={strengthData} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.2} />
+              <XAxis dataKey="date" />
+              <YAxis />
+              <Tooltip />
+              <Line type="monotone" dataKey="squat" stroke="#ef4444" strokeWidth={2} />
+            </LineChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
     </div>
   );
 };

--- a/src/components/ExportImport.jsx
+++ b/src/components/ExportImport.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { get, set } from 'idb-keyval';
+import Button from './ui/Button';
+import { Card, CardHeader, CardContent } from './ui/Card';
+
+const ExportImport = () => {
+  const handleExport = async () => {
+    const data = {
+      workouts: (await get('workouts')) || [],
+      nutrition_logs: (await get('nutrition_logs')) || [],
+      body_metrics: (await get('body_metrics')) || [],
+    };
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'gymbro-backup.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImport = async (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      const text = await file.text();
+      const json = JSON.parse(text);
+      if (json.workouts) await set('workouts', json.workouts);
+      if (json.nutrition_logs) await set('nutrition_logs', json.nutrition_logs);
+      if (json.body_metrics) await set('body_metrics', json.body_metrics);
+      alert('Data imported');
+    } catch (err) {
+      alert('Invalid file');
+    }
+  };
+
+  return (
+    <div className="space-y-4 max-w-xl mx-auto">
+      <h1 className="text-3xl font-bold md:text-4xl text-center">Export / Import</h1>
+      <Card className="mt-4">
+        <CardContent className="space-y-4">
+          <Button className="w-full" onClick={handleExport} aria-label="Export data">
+            Export Data
+          </Button>
+          <input
+            type="file"
+            accept="application/json"
+            onChange={handleImport}
+            aria-label="Import file"
+            className="w-full text-base md:text-lg leading-relaxed text-gray-700 dark:text-gray-100"
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default ExportImport;

--- a/src/components/NutritionTracker.jsx
+++ b/src/components/NutritionTracker.jsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { get, set } from 'idb-keyval';
 import { createClient } from '@supabase/supabase-js';
+import Button from './ui/Button';
+import Input from './ui/Input';
+import Label from './ui/Label';
+import { Card, CardHeader, CardContent } from './ui/Card';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
@@ -92,105 +96,112 @@ const NutritionTracker = () => {
   };
 
   return (
-    <div className="max-w-xl mx-auto space-y-4 dark:text-white">
-      <h2 className="text-4xl md:text-5xl font-bold text-white mb-4 text-center">
-        Nutrition Tracker
-      </h2>
-      <div className="grid grid-cols-5 gap-2">
-        <input
-          type="text"
-          placeholder="Meal"
-          value={mealName}
-          onChange={(e) => setMealName(e.target.value)}
-          className="border rounded p-2 col-span-2 dark:bg-gray-800"
-        />
-        <input
-          type="number"
-          placeholder="Cal"
-          value={calories}
-          onChange={(e) => setCalories(e.target.value)}
-          className="border rounded p-2 dark:bg-gray-800"
-        />
-        <input
-          type="number"
-          placeholder="Protein"
-          value={protein}
-          onChange={(e) => setProtein(e.target.value)}
-          className="border rounded p-2 dark:bg-gray-800"
-        />
-        <input
-          type="number"
-          placeholder="Carbs"
-          value={carbs}
-          onChange={(e) => setCarbs(e.target.value)}
-          className="border rounded p-2 dark:bg-gray-800"
-        />
-        <input
-          type="number"
-          placeholder="Fats"
-          value={fats}
-          onChange={(e) => setFats(e.target.value)}
-          className="border rounded p-2 dark:bg-gray-800"
-        />
-      </div>
-      <button
-        className="bg-blue-500 text-white rounded px-4 py-2 w-full"
-        onClick={addMeal}
-        disabled={!mealName}
-      >
+    <div className="max-w-xl mx-auto space-y-4">
+      <h1 className="text-3xl font-bold md:text-4xl text-center">Nutrition Tracker</h1>
+      <Card className="mt-4">
+        <CardContent className="grid grid-cols-5 gap-2">
+          <Input
+            type="text"
+            aria-label="Meal"
+            placeholder="Meal"
+            value={mealName}
+            onChange={(e) => setMealName(e.target.value)}
+            className="col-span-2"
+          />
+          <Input
+            type="number"
+            aria-label="Calories"
+            placeholder="Cal"
+            value={calories}
+            onChange={(e) => setCalories(e.target.value)}
+          />
+          <Input
+            type="number"
+            aria-label="Protein"
+            placeholder="Protein"
+            value={protein}
+            onChange={(e) => setProtein(e.target.value)}
+          />
+          <Input
+            type="number"
+            aria-label="Carbs"
+            placeholder="Carbs"
+            value={carbs}
+            onChange={(e) => setCarbs(e.target.value)}
+          />
+          <Input
+            type="number"
+            aria-label="Fats"
+            placeholder="Fats"
+            value={fats}
+            onChange={(e) => setFats(e.target.value)}
+          />
+        </CardContent>
+      </Card>
+      <Button className="w-full" onClick={addMeal} disabled={!mealName} aria-label="Add Meal">
         Add Meal
-      </button>
+      </Button>
 
       {meals.length > 0 && (
-        <div className="space-y-2">
-          <h3 className="font-medium">Today's Meals</h3>
-          <ul className="space-y-1">
-            {meals.map((meal, idx) => (
-              <li
-                key={idx}
-                className="flex justify-between items-center bg-gray-50 dark:bg-gray-700 p-2 rounded"
-              >
-                <div>
-                  <p className="font-semibold">{meal.name}</p>
-                  <p className="text-sm text-gray-600 dark:text-gray-300">
-                    {meal.calories} kcal | P {meal.protein} | C {meal.carbs} | F {meal.fats}
-                  </p>
-                </div>
-                <button
-                  className="text-red-600 dark:text-red-400"
-                  onClick={() => removeMeal(idx)}
+        <Card className="mt-4">
+          <CardHeader>
+            <h2 className="text-xl font-semibold md:text-2xl">Today's Meals</h2>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-1">
+              {meals.map((meal, idx) => (
+                <li
+                  key={idx}
+                  className="flex justify-between items-center bg-gray-50 dark:bg-gray-700 p-2 rounded"
                 >
-                  Remove
-                </button>
-              </li>
-            ))}
-          </ul>
-        </div>
+                  <div>
+                    <p className="font-semibold">{meal.name}</p>
+                    <p className="text-base md:text-lg leading-relaxed text-gray-700 dark:text-gray-100">
+                      {meal.calories} kcal | P {meal.protein} | C {meal.carbs} | F {meal.fats}
+                    </p>
+                  </div>
+                  <Button
+                    className="bg-transparent text-red-600 dark:text-red-400 hover:underline px-2 py-1"
+                    onClick={() => removeMeal(idx)}
+                    aria-label="Remove meal"
+                  >
+                    Remove
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
       )}
 
-      <div className="bg-gray-100 dark:bg-gray-800 p-4 rounded">
-        <h3 className="font-medium mb-2">Daily Totals</h3>
-        <p>
-          Calories: {totals.calories}/{TARGETS.calories}
-        </p>
-        <p>
-          Protein: {totals.protein}g/{TARGETS.protein}g
-        </p>
-        <p>
-          Carbs: {totals.carbs}g/{TARGETS.carbs}g
-        </p>
-        <p>
-          Fats: {totals.fats}g/{TARGETS.fats}g
-        </p>
-      </div>
+      <Card className="mt-4">
+        <CardHeader>
+          <h2 className="text-xl font-semibold md:text-2xl">Daily Totals</h2>
+        </CardHeader>
+        <CardContent>
+          <p className="text-base md:text-lg leading-relaxed text-gray-700 dark:text-gray-100">
+            Calories: {totals.calories}/{TARGETS.calories}
+          </p>
+          <p className="text-base md:text-lg leading-relaxed text-gray-700 dark:text-gray-100">
+            Protein: {totals.protein}g/{TARGETS.protein}g
+          </p>
+          <p className="text-base md:text-lg leading-relaxed text-gray-700 dark:text-gray-100">
+            Carbs: {totals.carbs}g/{TARGETS.carbs}g
+          </p>
+          <p className="text-base md:text-lg leading-relaxed text-gray-700 dark:text-gray-100">
+            Fats: {totals.fats}g/{TARGETS.fats}g
+          </p>
+        </CardContent>
+      </Card>
 
-      <button
-        className="bg-green-500 text-white rounded px-4 py-2 w-full"
+      <Button
+        className="bg-green-500 hover:bg-green-600 mt-4 w-full"
         onClick={saveLogs}
         disabled={!meals.length}
+        aria-label="Save Log"
       >
         Save Log
-      </button>
+      </Button>
     </div>
   );
 };

--- a/src/components/WorkoutPlanner.jsx
+++ b/src/components/WorkoutPlanner.jsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { get, set } from 'idb-keyval';
 import { createClient } from '@supabase/supabase-js';
+import Button from './ui/Button';
+import Input from './ui/Input';
+import Label from './ui/Label';
+import { Card, CardHeader, CardContent } from './ui/Card';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
@@ -99,108 +103,113 @@ const WorkoutPlanner = () => {
   };
 
   return (
-    <div>
-      <h2 className="text-4xl md:text-5xl font-bold text-white mb-4 text-center">
-        Workout Planner
-      </h2>
+    <div className="space-y-4">
+      <h1 className="text-3xl font-bold md:text-4xl text-center">Workout Planner</h1>
 
-      <div className="space-y-2 mb-6">
-        <div>
-          <label className="block text-sm font-medium mb-1">Exercise</label>
-          <select
-            className="w-full border rounded p-2"
-            value={selectedExercise}
-            onChange={(e) => setSelectedExercise(e.target.value)}
-          >
-            {exercisesList.map((ex) => (
-              <option key={ex} value={ex}>
-                {ex}
-              </option>
-            ))}
-          </select>
-        </div>
+      <Card className="mt-4">
+        <CardContent className="space-y-2">
+          <div>
+            <Label htmlFor="exercise">Exercise</Label>
+            <select
+              id="exercise"
+              className="w-full border rounded p-2 dark:bg-gray-800"
+              value={selectedExercise}
+              onChange={(e) => setSelectedExercise(e.target.value)}
+            >
+              {exercisesList.map((ex) => (
+                <option key={ex} value={ex}>
+                  {ex}
+                </option>
+              ))}
+            </select>
+          </div>
 
-        <div className="grid grid-cols-4 gap-2">
-          <input
-            type="number"
-            placeholder="Sets"
-            value={sets}
-            onChange={(e) => setSets(e.target.value)}
-            className="border rounded p-2"
-          />
-          <input
-            type="number"
-            placeholder="Reps"
-            value={reps}
-            onChange={(e) => setReps(e.target.value)}
-            className="border rounded p-2"
-          />
-          <input
-            type="number"
-            placeholder="Weight"
-            value={weight}
-            onChange={(e) => setWeight(e.target.value)}
-            className="border rounded p-2"
-          />
-          <input
-            type="number"
-            placeholder="RPE"
-            value={rpe}
-            onChange={(e) => setRpe(e.target.value)}
-            className="border rounded p-2"
-          />
-        </div>
+          <div className="grid grid-cols-4 gap-2">
+            <Input
+              type="number"
+              aria-label="Sets"
+              placeholder="Sets"
+              value={sets}
+              onChange={(e) => setSets(e.target.value)}
+            />
+            <Input
+              type="number"
+              aria-label="Reps"
+              placeholder="Reps"
+              value={reps}
+              onChange={(e) => setReps(e.target.value)}
+            />
+            <Input
+              type="number"
+              aria-label="Weight"
+              placeholder="Weight"
+              value={weight}
+              onChange={(e) => setWeight(e.target.value)}
+            />
+            <Input
+              type="number"
+              aria-label="RPE"
+              placeholder="RPE"
+              value={rpe}
+              onChange={(e) => setRpe(e.target.value)}
+            />
+          </div>
 
-        <button
-          className="bg-blue-500 text-white rounded px-4 py-2 w-full"
-          onClick={addExercise}
-        >
-          {editIndex !== null ? 'Update Exercise' : 'Add Exercise'}
-        </button>
-      </div>
+          <Button className="w-full" onClick={addExercise} aria-label="Add Exercise">
+            {editIndex !== null ? 'Update Exercise' : 'Add Exercise'}
+          </Button>
+        </CardContent>
+      </Card>
 
       {exercises.length > 0 && (
-        <div className="mb-6">
-          <h3 className="font-medium mb-2">Workout Log</h3>
-          <ul className="space-y-2">
-            {exercises.map((ex, idx) => (
-              <li
-                key={idx}
-                className="flex justify-between items-center bg-gray-50 p-2 rounded"
-              >
-                <div>
-                  <p className="font-semibold">{ex.exercise}</p>
-                  <p className="text-sm text-gray-600">
-                    Sets: {ex.sets} Reps: {ex.reps} Weight: {ex.weight} RPE: {ex.rpe}
-                  </p>
-                </div>
-                <div className="space-x-2">
-                  <button
-                    className="text-blue-600"
-                    onClick={() => handleEdit(idx)}
-                  >
-                    Edit
-                  </button>
-                  <button
-                    className="text-red-600"
-                    onClick={() => handleRemove(idx)}
-                  >
-                    Remove
-                  </button>
-                </div>
-              </li>
-            ))}
-          </ul>
-        </div>
+        <Card className="mt-4">
+          <CardHeader>
+            <h2 className="text-xl font-semibold md:text-2xl">Workout Log</h2>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-2">
+              {exercises.map((ex, idx) => (
+                <li
+                  key={idx}
+                  className="flex justify-between items-center bg-gray-50 dark:bg-gray-700 p-2 rounded"
+                >
+                  <div>
+                    <p className="font-semibold">{ex.exercise}</p>
+                    <p className="text-base md:text-lg leading-relaxed text-gray-700 dark:text-gray-100">
+                      Sets: {ex.sets} Reps: {ex.reps} Weight: {ex.weight} RPE: {ex.rpe}
+                    </p>
+                  </div>
+                  <div className="space-x-2">
+                    <Button
+                      className="bg-transparent text-blue-600 hover:underline px-2 py-1"
+                      onClick={() => handleEdit(idx)}
+                      aria-label="Edit exercise"
+                    >
+                      Edit
+                    </Button>
+                    <Button
+                      className="bg-transparent text-red-600 hover:underline px-2 py-1"
+                      onClick={() => handleRemove(idx)}
+                      aria-label="Remove exercise"
+                    >
+                      Remove
+                    </Button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
       )}
 
-      <button
-        className="bg-green-500 text-white rounded px-4 py-2"
+      <Button
+        className="bg-green-500 hover:bg-green-600 mt-4"
         onClick={saveWorkout}
         disabled={!exercises.length}
+        aria-label="Save Workout"
       >
         Save Workout
-      </button>
+      </Button>
     </div>
   );
 };

--- a/src/components/ui/Button.jsx
+++ b/src/components/ui/Button.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const Button = React.forwardRef(({ className = '', ...props }, ref) => (
+  <button
+    ref={ref}
+    className={`inline-flex items-center justify-center rounded-md bg-blue-600 hover:bg-blue-700 text-white text-base font-medium px-4 py-2 transition-colors disabled:opacity-50 disabled:pointer-events-none ${className}`}
+    {...props}
+  />
+));
+
+Button.displayName = 'Button';
+export default Button;

--- a/src/components/ui/Card.jsx
+++ b/src/components/ui/Card.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export function Card({ className = '', ...props }) {
+  return (
+    <div className={`bg-white dark:bg-gray-800 rounded shadow ${className}`} {...props} />
+  );
+}
+
+export function CardHeader({ className = '', ...props }) {
+  return (
+    <div className={`border-b border-gray-200 dark:border-gray-700 px-4 py-2 ${className}`} {...props} />
+  );
+}
+
+export function CardContent({ className = '', ...props }) {
+  return <div className={`p-4 ${className}`} {...props} />;
+}

--- a/src/components/ui/Input.jsx
+++ b/src/components/ui/Input.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const Input = React.forwardRef(({ className = '', ...props }, ref) => (
+  <input
+    ref={ref}
+    className={`border rounded px-3 py-2 w-full bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 ${className}`}
+    {...props}
+  />
+));
+
+Input.displayName = 'Input';
+export default Input;

--- a/src/components/ui/Label.jsx
+++ b/src/components/ui/Label.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const Label = ({ className = '', ...props }) => (
+  <label
+    className={`block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300 ${className}`}
+    {...props}
+  />
+);
+
+export default Label;

--- a/src/components/ui/Link.jsx
+++ b/src/components/ui/Link.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+
+const Link = React.forwardRef(({ className = '', ...props }, ref) => (
+  <RouterLink
+    ref={ref}
+    className={`text-blue-600 dark:text-blue-400 hover:underline text-base font-medium ${className}`}
+    {...props}
+  />
+));
+
+Link.displayName = 'Link';
+export default Link;


### PR DESCRIPTION
## Summary
- create small shadcn-style UI library (Button, Card, Input, Label, Link)
- refactor App navigation to use the new Link component
- restyle WorkoutPlanner with cards and new heading hierarchy
- restyle NutritionTracker with cards and uniform text
- restyle BodyMetrics inputs and log section
- update Charts layout using Card components
- add ExportImport page for backup and restore

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d4ece52e0832cac09e5717fc2ed23