### PR TITLE
Fix Vite base path on Netlify

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Remember to provide `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` during the 
 3. Netlify uses `netlify.toml` to build and deploy the app. The configuration
    already points at `backend/functions` for serverless functions and publishes
    the `dist` folder.
+   The Vite config automatically detects the `NETLIFY` environment variable so
+   asset paths work correctly when deployed to Netlify.
 4. To preview locally run:
    ```bash
    npm run netlify

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,13 +1,19 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+/**
+ * Vite configuration
+ *
+ * The `base` option controls the path prepended to asset URLs in the built
+ * index.html. When deploying to GitHub Pages the site is served from
+ * `https://<user>.github.io/<repo>/` so we need to prefix assets with the repo
+ * name. Netlify, on the other hand, serves the site from the domain root and
+ * requires `base` to be `/`. Netlify automatically sets the `NETLIFY`
+ * environment variable during the build which we can use to switch between the
+ * two.
+ */
 export default defineConfig({
-  // When deploying to GitHub Pages the site will be served from
-  // https://<user>.github.io/<repo>/, so we need to prefix asset URLs
-  // with the repository name. This prevents requests for assets like
-  // /assets/index.js from returning the 404 page (served as text/html)
-  // which caused the "disallowed MIME type" error.
-  base: '/GymBroRecipes/',
+  base: process.env.NETLIFY ? '/' : '/GymBroRecipes/',
   plugins: [react()],
   server: {
     open: true,


### PR DESCRIPTION
## Summary
- detect Netlify build and switch Vite `base` path to `/`
- document the automatic Netlify handling in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d51a9d218832c8378a5c46b7cf877