### PR TITLE
Fix Home navigation link path

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,7 +31,7 @@ function App() {
   }
 
   return (
-    <Router>
+    <Router basename={import.meta.env.BASE_URL}>
       <div className="min-h-screen flex flex-col">
         <header className="sticky top-0 z-10 bg-slate-900/50 backdrop-blur">
           <div className="container mx-auto px-6 py-4 flex justify-between items-center">


### PR DESCRIPTION
## Summary
- use `basename={import.meta.env.BASE_URL}` with `BrowserRouter`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d5387ee74832cbb63213850221548