### PR TITLE
Improve food search UX and training metrics

### DIFF
--- a/src/components/FoodSearch.jsx
+++ b/src/components/FoodSearch.jsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+import Button from './ui/Button';
+import Input from './ui/Input';
+import { Card, CardHeader, CardContent } from './ui/Card';
+
+const FoodSearch = ({ onSelect }) => {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  const searchFoods = async () => {
+    if (!query) return;
+    setLoading(true);
+    try {
+      const res = await fetch(
+        `https://world.openfoodfacts.org/cgi/search.pl?search_terms=${encodeURIComponent(
+          query,
+        )}&search_simple=1&action=process&json=1&page_size=5`,
+      );
+      const data = await res.json();
+      const items = (data.products || []).map((p) => ({
+        id: p.id,
+        name: p.product_name || 'Unknown',
+        calories: Number(p.nutriments?.['energy-kcal_100g']) || 0,
+        protein: Number(p.nutriments?.proteins_100g) || 0,
+        carbs: Number(p.nutriments?.carbohydrates_100g) || 0,
+        fats: Number(p.nutriments?.fat_100g) || 0,
+      }));
+      setResults(items);
+    } catch (err) {
+      console.error('Search failed', err);
+      setResults([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Card className="mt-4">
+      <CardHeader>
+        <h2 className="text-xl font-semibold md:text-2xl">Food Search</h2>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <div className="flex space-x-2">
+          <Input
+            aria-label="Search food"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search..."
+          />
+          <Button onClick={searchFoods} disabled={loading || !query} aria-label="Search">
+            {loading ? 'Searching...' : 'Search'}
+          </Button>
+        </div>
+        {results.length > 0 ? (
+          <ul className="space-y-2" aria-live="polite">
+            {results.map((item) => (
+              <li
+                key={item.id}
+                className="flex justify-between bg-gray-50 dark:bg-gray-700 p-2 rounded"
+              >
+                <div>
+                  <p className="font-semibold">{item.name}</p>
+                  <p className="text-base md:text-lg leading-relaxed text-gray-700 dark:text-gray-100">
+                    {item.calories} kcal | P {item.protein} | C {item.carbs} | F {item.fats}
+                  </p>
+                </div>
+                <Button
+                  className="bg-transparent text-blue-600 hover:underline px-2 py-1"
+                  onClick={() => onSelect(item)}
+                  aria-label={`Add ${item.name}`}
+                >
+                  Add
+                </Button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          !loading && query && <p className="text-gray-500">No results found.</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default FoodSearch;

--- a/src/components/FoodSearch.jsx
+++ b/src/components/FoodSearch.jsx
@@ -76,7 +76,12 @@ const FoodSearch = ({ onSelect }) => {
             ))}
           </ul>
         ) : (
-          !loading && query && <p className="text-gray-500">No results found.</p>
+          !loading &&
+          query && (
+            <p className="text-gray-500" aria-live="polite">
+              No results found.
+            </p>
+          )
         )}
       </CardContent>
     </Card>

--- a/src/components/NutritionTracker.jsx
+++ b/src/components/NutritionTracker.jsx
@@ -5,6 +5,7 @@ import Button from './ui/Button';
 import Input from './ui/Input';
 import Label from './ui/Label';
 import { Card, CardHeader, CardContent } from './ui/Card';
+import FoodSearch from './FoodSearch';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
@@ -28,6 +29,7 @@ const NutritionTracker = () => {
   const [carbs, setCarbs] = useState('');
   const [fats, setFats] = useState('');
   const [meals, setMeals] = useState([]);
+  const [showSearch, setShowSearch] = useState(false);
 
   useEffect(() => {
     async function loadUser() {
@@ -55,6 +57,15 @@ const NutritionTracker = () => {
     };
     setMeals([...meals, newMeal]);
     resetForm();
+  };
+
+  const handleSelectFood = (food) => {
+    setMealName(food.name);
+    setCalories(food.calories);
+    setProtein(food.protein);
+    setCarbs(food.carbs);
+    setFats(food.fats);
+    setShowSearch(false);
   };
 
   const removeMeal = (index) => {
@@ -138,9 +149,18 @@ const NutritionTracker = () => {
           />
         </CardContent>
       </Card>
-      <Button className="w-full" onClick={addMeal} disabled={!mealName} aria-label="Add Meal">
-        Add Meal
-      </Button>
+      <div className="flex space-x-2">
+        <Button className="flex-1" onClick={addMeal} disabled={!mealName} aria-label="Add Meal">
+          Add Meal
+        </Button>
+        <Button
+          className="flex-1 bg-gray-600 hover:bg-gray-700"
+          onClick={() => setShowSearch((s) => !s)}
+          aria-label="Search food database"
+        >
+          Search Food
+        </Button>
+      </div>
 
       {meals.length > 0 && (
         <Card className="mt-4">
@@ -173,6 +193,8 @@ const NutritionTracker = () => {
           </CardContent>
         </Card>
       )}
+
+      {showSearch && <FoodSearch onSelect={handleSelectFood} />}
 
       <Card className="mt-4">
         <CardHeader>

--- a/src/components/TrainingMetrics.jsx
+++ b/src/components/TrainingMetrics.jsx
@@ -27,7 +27,6 @@ const TrainingMetrics = ({ exercises = [] }) => {
     exercises.reduce((acc, ex) => acc + (Number(ex.rpe) || 0), 0) /
     exercises.length
   ).toFixed(1);
-
   return (
     <Card className="mt-4">
       <CardHeader>

--- a/src/components/TrainingMetrics.jsx
+++ b/src/components/TrainingMetrics.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Card, CardHeader, CardContent } from './ui/Card';
+
+const calculate1RM = (weight, reps) => {
+  const w = Number(weight) || 0;
+  const r = Number(reps) || 0;
+  if (!w || !r) return 0;
+  return Math.round(w * (1 + r / 30));
+};
+
+const TrainingMetrics = ({ exercises = [] }) => {
+  if (!exercises.length) return null;
+
+  const totalVolume = exercises.reduce((acc, ex) => {
+    const sets = Number(ex.sets) || 0;
+    const reps = Number(ex.reps) || 0;
+    const weight = Number(ex.weight) || 0;
+    return acc + sets * reps * weight;
+  }, 0);
+
+  const best1RM = exercises.reduce((max, ex) => {
+    const est = calculate1RM(ex.weight, ex.reps);
+    return est > max ? est : max;
+  }, 0);
+
+  const avgRPE = (
+    exercises.reduce((acc, ex) => acc + (Number(ex.rpe) || 0), 0) /
+    exercises.length
+  ).toFixed(1);
+
+  return (
+    <Card className="mt-4">
+      <CardHeader>
+        <h2 className="text-xl font-semibold md:text-2xl">Training Metrics</h2>
+      </CardHeader>
+      <CardContent>
+        <p className="text-base md:text-lg leading-relaxed text-gray-700 dark:text-gray-100">
+          Total Volume: {totalVolume} kg
+        </p>
+        <p className="text-base md:text-lg leading-relaxed text-gray-700 dark:text-gray-100">
+          Best Estimated 1RM: {best1RM} kg
+        </p>
+        <p className="text-base md:text-lg leading-relaxed text-gray-700 dark:text-gray-100">
+          Avg RPE: {avgRPE}
+        </p>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default TrainingMetrics;

--- a/src/components/WorkoutPlanner.jsx
+++ b/src/components/WorkoutPlanner.jsx
@@ -5,6 +5,7 @@ import Button from './ui/Button';
 import Input from './ui/Input';
 import Label from './ui/Label';
 import { Card, CardHeader, CardContent } from './ui/Card';
+import TrainingMetrics from './TrainingMetrics';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
@@ -201,6 +202,8 @@ const WorkoutPlanner = () => {
           </CardContent>
         </Card>
       )}
+
+      <TrainingMetrics exercises={exercises} />
 
       <Button
         className="bg-green-500 hover:bg-green-600 mt-4"

--- a/src/components/__tests__/FoodSearch.test.jsx
+++ b/src/components/__tests__/FoodSearch.test.jsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import FoodSearch from '../FoodSearch';
+import React from 'react';
+
+test('renders Food Search heading', () => {
+  render(<FoodSearch onSelect={() => {}} />);
+  const heading = screen.getByText(/Food Search/i);
+  expect(heading).toBeInTheDocument();
+});

--- a/src/components/__tests__/FoodSearch.test.jsx
+++ b/src/components/__tests__/FoodSearch.test.jsx
@@ -1,9 +1,26 @@
 import { render, screen } from '@testing-library/react';
 import FoodSearch from '../FoodSearch';
 import React from 'react';
+import { fireEvent, waitFor } from '@testing-library/react';
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
 
 test('renders Food Search heading', () => {
   render(<FoodSearch onSelect={() => {}} />);
   const heading = screen.getByText(/Food Search/i);
   expect(heading).toBeInTheDocument();
+});
+
+test('shows no results message when search returns empty', async () => {
+  jest.spyOn(global, 'fetch').mockResolvedValue({
+    json: () => Promise.resolve({ products: [] }),
+  });
+  render(<FoodSearch onSelect={() => {}} />);
+  fireEvent.change(screen.getByLabelText(/Search food/i), {
+    target: { value: 'foo' },
+  });
+  fireEvent.click(screen.getByLabelText(/Search/));
+  await waitFor(() => screen.getByText(/No results found/i));
 });

--- a/src/components/__tests__/TrainingMetrics.test.jsx
+++ b/src/components/__tests__/TrainingMetrics.test.jsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import TrainingMetrics from '../TrainingMetrics';
+import React from 'react';
+
+test('renders Training Metrics heading', () => {
+  render(<TrainingMetrics exercises={[{weight:10,reps:5,sets:1,rpe:8}]} />);
+  const heading = screen.getByText(/Training Metrics/i);
+  expect(heading).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- enhance FoodSearch with loading state and no-results message
- compute average RPE in TrainingMetrics
- add simple TrainingMetrics test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d562a4058832c8e6cdcffb9890cba