### PR TITLE
Add stats page and exercise search

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import WorkoutPlanner from './components/WorkoutPlanner';
 import NutritionTracker from './components/NutritionTracker';
 import BodyMetrics from './components/BodyMetrics';
 import ProgressPhotos from './components/ProgressPhotos';
+import Stats from './components/Stats';
 import UpgradeBanner from './components/UpgradeBanner';
 import Link from './components/ui/Link';
 
@@ -42,6 +43,7 @@ function App() {
               <Link className="text-base font-medium text-gray-300 hover:text-blue-400 transition-colors" to="/nutrition">Nutrition</Link>
               <Link className="text-base font-medium text-gray-300 hover:text-blue-400 transition-colors" to="/metrics">Metrics</Link>
               <Link className="text-base font-medium text-gray-300 hover:text-blue-400 transition-colors" to="/photos">Photos</Link>
+              <Link className="text-base font-medium text-gray-300 hover:text-blue-400 transition-colors" to="/stats">Stats</Link>
             </nav>
           </div>
         </header>
@@ -55,6 +57,7 @@ function App() {
             <Route path="/nutrition" element={<NutritionTracker />} />
             <Route path="/metrics" element={<BodyMetrics />} />
             <Route path="/photos" element={<ProgressPhotos />} />
+            <Route path="/stats" element={<Stats />} />
           </Routes>
         </main>
 

--- a/src/components/ExerciseSearch.jsx
+++ b/src/components/ExerciseSearch.jsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import Button from './ui/Button';
+import Input from './ui/Input';
+import { Card, CardHeader, CardContent } from './ui/Card';
+
+const ExerciseSearch = ({ onSelect }) => {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  const search = async () => {
+    if (!query) return;
+    setLoading(true);
+    try {
+      const res = await fetch(
+        `https://wger.de/api/v2/exercise/?language=2&limit=8&search=${encodeURIComponent(query)}`
+      );
+      const data = await res.json();
+      const items = (data.results || []).map((ex) => ({ id: ex.id, name: ex.name }));
+      setResults(items);
+    } catch (err) {
+      console.error('Exercise search failed', err);
+      setResults([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Card className="mt-4">
+      <CardHeader>
+        <h2 className="text-xl font-semibold md:text-2xl">Exercise Search</h2>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <div className="flex space-x-2">
+          <Input
+            aria-label="Search exercise"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search..."
+          />
+          <Button onClick={search} disabled={loading || !query} aria-label="Search">
+            Search
+          </Button>
+        </div>
+        <ul className="space-y-2">
+          {results.map((item) => (
+            <li
+              key={item.id}
+              className="flex justify-between bg-gray-50 dark:bg-gray-700 p-2 rounded"
+            >
+              <p className="font-semibold">{item.name}</p>
+              <Button
+                className="bg-transparent text-blue-600 hover:underline px-2 py-1"
+                onClick={() => onSelect(item)}
+                aria-label={`Add ${item.name}`}
+              >
+                Add
+              </Button>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ExerciseSearch;

--- a/src/components/Stats.jsx
+++ b/src/components/Stats.jsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+import { get } from 'idb-keyval';
+import { createClient } from '@supabase/supabase-js';
+import Charts from './Charts';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+const supabase = supabaseUrl && supabaseAnonKey ? createClient(supabaseUrl, supabaseAnonKey) : null;
+
+const Stats = () => {
+  const [user, setUser] = useState(null);
+  const [bodyMetrics, setBodyMetrics] = useState([]);
+  const [nutrition, setNutrition] = useState([]);
+  const [workouts, setWorkouts] = useState([]);
+
+  useEffect(() => {
+    async function loadUser() {
+      const stored = await get('user');
+      setUser(stored || { is_paid: false });
+    }
+    loadUser();
+  }, []);
+
+  useEffect(() => {
+    if (user) {
+      loadData();
+    }
+  }, [user]);
+
+  const loadData = async () => {
+    if (!user || !user.is_paid || !supabase) {
+      const metrics = (await get('body_metrics')) || [];
+      const nutritionLogs = (await get('nutrition_logs')) || [];
+      const workoutsLocal = (await get('workouts')) || [];
+      setBodyMetrics(metrics);
+      setNutrition(nutritionLogs);
+      setWorkouts(workoutsLocal);
+    } else {
+      try {
+        const [{ data: m }, { data: n }, { data: w }] = await Promise.all([
+          supabase.from('body_metrics').select('*'),
+          supabase.from('nutrition_logs').select('*'),
+          supabase.from('workouts').select('*'),
+        ]);
+        setBodyMetrics(m || []);
+        setNutrition(n || []);
+        setWorkouts(w || []);
+      } catch (err) {
+        console.error('Error loading data', err);
+      }
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-3xl font-bold md:text-4xl text-center">Progress Stats</h1>
+      <Charts
+        bodyMetricsData={bodyMetrics}
+        nutritionData={nutrition}
+        workoutData={workouts}
+      />
+    </div>
+  );
+};
+
+export default Stats;

--- a/src/components/WorkoutPlanner.jsx
+++ b/src/components/WorkoutPlanner.jsx
@@ -6,6 +6,7 @@ import Input from './ui/Input';
 import Label from './ui/Label';
 import { Card, CardHeader, CardContent } from './ui/Card';
 import TrainingMetrics from './TrainingMetrics';
+import ExerciseSearch from './ExerciseSearch';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
@@ -31,6 +32,7 @@ const WorkoutPlanner = () => {
   const [rpe, setRpe] = useState('');
   const [exercises, setExercises] = useState([]);
   const [editIndex, setEditIndex] = useState(null);
+  const [showSearch, setShowSearch] = useState(false);
 
   useEffect(() => {
     async function loadUser() {
@@ -47,6 +49,11 @@ const WorkoutPlanner = () => {
     setWeight('');
     setRpe('');
     setEditIndex(null);
+  };
+
+  const handleSelectFromSearch = (exercise) => {
+    setSelectedExercise(exercise.name);
+    setShowSearch(false);
   };
 
   const addExercise = () => {
@@ -159,8 +166,17 @@ const WorkoutPlanner = () => {
           <Button className="w-full" onClick={addExercise} aria-label="Add Exercise">
             {editIndex !== null ? 'Update Exercise' : 'Add Exercise'}
           </Button>
+          <Button
+            className="w-full bg-gray-600 hover:bg-gray-700"
+            onClick={() => setShowSearch((s) => !s)}
+            aria-label="Search exercises"
+          >
+            Search Exercises
+          </Button>
         </CardContent>
       </Card>
+
+      {showSearch && <ExerciseSearch onSelect={handleSelectFromSearch} />}
 
       {exercises.length > 0 && (
         <Card className="mt-4">

--- a/src/components/__tests__/Stats.test.jsx
+++ b/src/components/__tests__/Stats.test.jsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Stats from '../Stats';
+import React from 'react';
+
+test('renders Progress Stats heading', () => {
+  render(<Stats />);
+  const heading = screen.getByText(/Progress Stats/i);
+  expect(heading).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add `ExerciseSearch` for finding exercises from wger
- extend `WorkoutPlanner` with exercise search panel
- show progress charts via new `Stats` component and add route
- test that stats page renders

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d61953cd4832c9f42e975368bacc5